### PR TITLE
added 4626 properties test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,6 @@
 [submodule "lib/erc4626-tests"]
 	path = lib/erc4626-tests
 	url = https://github.com/a16z/erc4626-tests
+[submodule "lib/properties"]
+	path = lib/properties
+	url = https://github.com/crytic/properties

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <h1 align="center"> Puffer Vault </h1> 
+# <h1 align="center"> Puffer Vault </h1>
 [![Website][Website-badge]][Website] [![Docs][docs-badge]][docs]
   [![Discord][discord-badge]][discord] [![X][X-badge]][X] [![Foundry][foundry-badge]][foundry]
 
@@ -47,3 +47,12 @@ Installing dependencies and running tests can be executed running:
 ```
 ETH_RPC_URL=https://mainnet.infura.io/v3/YOUR_KEY forge test -vvvv
 ```
+
+# Echidna
+To install Echidna, see the instructions [here](https://github.com/crytic/echidna). To use Echidna, run the following command from the project's root:
+```bash
+forge install crytic/properties --no-commit
+echidna . --contract EchidnaPufferVaultV2 --config src/echidna/config.yaml
+```
+For more information see the properties [README](https://github.com/crytic/properties/tree/main).
+

--- a/src/PufferVaultV2.sol
+++ b/src/PufferVaultV2.sol
@@ -45,6 +45,11 @@ contract PufferVaultV2 is PufferVault, IPufferVaultV2 {
     ) PufferVault(stETH, lidoWithdrawalQueue, stETHStrategy, eigenStrategyManager) {
         _WETH = weth;
         PUFFER_ORACLE = oracle;
+        ERC4626Storage storage erc4626Storage = _getERC4626StorageInternal();
+        erc4626Storage._asset = _WETH;
+        _setDailyWithdrawalLimit(100 ether);
+        _updateDailyWithdrawals(0);
+        _setExitFeeBasisPoints(100); // 1%
         _disableInitializers();
     }
 

--- a/src/echidna/EchidnaPufferVaultV2.sol
+++ b/src/echidna/EchidnaPufferVaultV2.sol
@@ -1,25 +1,24 @@
 pragma solidity ^0.8.0;
 
-import {CryticERC4626PropertyTests} from "properties/ERC4626/ERC4626PropertyTests.sol";
-import {PufferVaultV2} from "../PufferVaultV2.sol";
-import {WETH9} from "../../test/mocks/WETH9.sol";
-import {stETHMock} from "../../test/mocks/stETHMock.sol";
-import {MockPufferOracle} from "../../test/mocks/MockPufferOracle.sol";
-import {EigenLayerManagerMock} from "../../test/mocks/EigenLayerManagerMock.sol";
-import {LidoWithdrawalQueueMock} from "../../test/mocks/LidoWithdrawalQueueMock.sol";
-import {stETHStrategyMock} from "../../test/mocks/stETHStrategyMock.sol";
- import{TestERC20Token} from "properties/ERC4626/util/TestERC20Token.sol";
+import { CryticERC4626PropertyTests } from "properties/ERC4626/ERC4626PropertyTests.sol";
+import { PufferVaultV2 } from "../PufferVaultV2.sol";
+import { WETH9 } from "../../test/mocks/WETH9.sol";
+import { stETHMock } from "../../test/mocks/stETHMock.sol";
+import { MockPufferOracle } from "../../test/mocks/MockPufferOracle.sol";
+import { EigenLayerManagerMock } from "../../test/mocks/EigenLayerManagerMock.sol";
+import { LidoWithdrawalQueueMock } from "../../test/mocks/LidoWithdrawalQueueMock.sol";
+import { stETHStrategyMock } from "../../test/mocks/stETHStrategyMock.sol";
+import { TestERC20Token } from "properties/ERC4626/util/TestERC20Token.sol";
 
 contract EchidnaPufferVaultV2 is CryticERC4626PropertyTests {
-
     constructor() {
         WETH9 weth = new WETH9();
         stETHMock stETH = new stETHMock();
         MockPufferOracle oracle = new MockPufferOracle();
         EigenLayerManagerMock eigenlayer = new EigenLayerManagerMock();
-        LidoWithdrawalQueueMock lido= new LidoWithdrawalQueueMock();
-        stETHStrategyMock stETHStrategy= new stETHStrategyMock();
-        PufferVaultV2 vault = new PufferVaultV2(stETH,weth,lido,stETHStrategy,eigenlayer,oracle);
-        initialize(address(vault),address(weth),false);
+        LidoWithdrawalQueueMock lido = new LidoWithdrawalQueueMock();
+        stETHStrategyMock stETHStrategy = new stETHStrategyMock();
+        PufferVaultV2 vault = new PufferVaultV2(stETH, weth, lido, stETHStrategy, eigenlayer, oracle);
+        initialize(address(vault), address(weth), false);
     }
 }

--- a/src/echidna/EchidnaPufferVaultV2.sol
+++ b/src/echidna/EchidnaPufferVaultV2.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.8.0;
+
+import {CryticERC4626PropertyTests} from "properties/ERC4626/ERC4626PropertyTests.sol";
+import {PufferVaultV2} from "../PufferVaultV2.sol";
+import {WETH9} from "../../test/mocks/WETH9.sol";
+import {stETHMock} from "../../test/mocks/stETHMock.sol";
+import {MockPufferOracle} from "../../test/mocks/MockPufferOracle.sol";
+import {EigenLayerManagerMock} from "../../test/mocks/EigenLayerManagerMock.sol";
+import {LidoWithdrawalQueueMock} from "../../test/mocks/LidoWithdrawalQueueMock.sol";
+import {stETHStrategyMock} from "../../test/mocks/stETHStrategyMock.sol";
+ import{TestERC20Token} from "properties/ERC4626/util/TestERC20Token.sol";
+
+contract EchidnaPufferVaultV2 is CryticERC4626PropertyTests {
+
+    constructor() {
+        WETH9 weth = new WETH9();
+        stETHMock stETH = new stETHMock();
+        MockPufferOracle oracle = new MockPufferOracle();
+        EigenLayerManagerMock eigenlayer = new EigenLayerManagerMock();
+        LidoWithdrawalQueueMock lido= new LidoWithdrawalQueueMock();
+        stETHStrategyMock stETHStrategy= new stETHStrategyMock();
+        PufferVaultV2 vault = new PufferVaultV2(stETH,weth,lido,stETHStrategy,eigenlayer,oracle);
+        initialize(address(vault),address(weth),false);
+    }
+}

--- a/src/echidna/config.yaml
+++ b/src/echidna/config.yaml
@@ -1,0 +1,5 @@
+corpusDir: "tests/echidna-corpus"
+testMode: assertion
+testLimit: 1000000
+deployer: "0x10000"
+sender: ["0x10000"]

--- a/test/mocks/WETH9.sol
+++ b/test/mocks/WETH9.sol
@@ -70,4 +70,12 @@ contract WETH9 is IWETH {
 
         return true;
     }
+    function forceApproval(
+        address account,
+        address spender,
+        uint256 amount
+    ) public {
+        allowance[account][spender] = amount;
+        emit Approval(account, spender, amount);
+    }
 }

--- a/test/mocks/WETH9.sol
+++ b/test/mocks/WETH9.sol
@@ -70,11 +70,8 @@ contract WETH9 is IWETH {
 
         return true;
     }
-    function forceApproval(
-        address account,
-        address spender,
-        uint256 amount
-    ) public {
+
+    function forceApproval(address account, address spender, uint256 amount) public {
         allowance[account][spender] = amount;
         emit Approval(account, spender, amount);
     }

--- a/test/mocks/stETHMock.sol
+++ b/test/mocks/stETHMock.sol
@@ -3,8 +3,9 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
+import "../../src/interface/Lido/IStETH.sol";
 
-contract stETHMock is ERC20, ERC20Burnable {
+contract stETHMock is IStETH,ERC20, ERC20Burnable {
     constructor() ERC20("Mock stETH", "mockStETH") { }
 
     uint256 public totalShares;
@@ -36,6 +37,18 @@ contract stETHMock is ERC20, ERC20Burnable {
         totalPooledEther = _totalPooledEther;
     }
 
+    function getTotalPooledEther() external view returns (uint256) {
+        return totalPooledEther;
+    }
+
+    function sharesOf(address _account) external view returns (uint256) {
+        //not implemented, just there for IstETH conformance
+    }
+
+    function transferShares(address _recipient, uint256 _sharesAmount) external returns (uint256) {
+        //not implemented, just there for IstETH conformance
+    }
+
     function getPooledEthByShares(uint256 _sharesAmount) public view returns (uint256) {
         if (totalShares == 0) {
             return 0;
@@ -48,5 +61,9 @@ contract stETHMock is ERC20, ERC20Burnable {
             return 0;
         }
         return _pooledEthAmount * totalShares / totalPooledEther;
+    }
+
+    function totalSupply() public view override(ERC20,IStETH) returns (uint256) {
+        return super.totalSupply();
     }
 }

--- a/test/mocks/stETHMock.sol
+++ b/test/mocks/stETHMock.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "../../src/interface/Lido/IStETH.sol";
 
-contract stETHMock is IStETH,ERC20, ERC20Burnable {
+contract stETHMock is IStETH, ERC20, ERC20Burnable {
     constructor() ERC20("Mock stETH", "mockStETH") { }
 
     uint256 public totalShares;
@@ -63,7 +63,7 @@ contract stETHMock is IStETH,ERC20, ERC20Burnable {
         return _pooledEthAmount * totalShares / totalPooledEther;
     }
 
-    function totalSupply() public view override(ERC20,IStETH) returns (uint256) {
+    function totalSupply() public view override(ERC20, IStETH) returns (uint256) {
         return super.totalSupply();
     }
 }


### PR DESCRIPTION
This PR adds preliminary fuzz tests based on the `crytic/properties` repo. We recommend further improving this suite by  refining the test suite to handle all external user flows as well as updating the internal testing mode to add accounting invariants. For more information please check out the updated README.